### PR TITLE
Rework a setup function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # venkat.nvim
-nvim plugin to execute on save main source files
+nvim plugin to execute on-save source files and prints back the result in a pop up window.
+Release the window with <ESC>.
 
-This plugin is inspired by Venkat Subramanian usage of TextMate in his Presentations
+This plugin is inspired by Venkat Subramanian usage of TextMate in his presentations
 and by TJ with his excellent autocmd tutorial.
 
 By default whenever saving a main.go, main.py, main.rs, main.java, nvim will compile and run, and preview 
@@ -10,32 +11,45 @@ the result in a floating window.
 Here's the default configuration:
 
 ```lua
-require('venkat').config.languages = {
+languages = {
     go = { cmdline = "go run %s", pattern = "main.go" },
     java = { cmdline = "java %s", pattern = "Main.java" },
     python = { cmdline = "python %s", pattern = "main.py" },
-    rust = { cmdline = "cargo -Zscript %s", pattern = "main.rs" },
+    rust = { cmdline = "cargo %s", pattern = "main.rs" },
     zig = { cmdline = "zig run %s", pattern = "main.zig" },
 }
+
 ```
 
-Install using packer:
+The use of pattern here adheres to nvim's file pattern usage. 
+Because executing all the file on save is not usually what you want while developing, a pattern can make this 
+more handy. Consider these examples:
+```lua
+-- all python files under demos a relative demos directory:
+    pattern = "*/demos/*.py"
+-- all python files under demos a relative demos directory and any main.py:
+    pattern = "demos/*.py,main.py"
+```
+
+For more info see `:help file-pattern`
+
+## Install using packer:
 
 ```lua
     use('rgolangh/venkat.nvim')
 ```
 
-Expand the config in `init.lua` or `$HOME/.config/nvim/after/plugin/venkat.lua` :
+If you want to customize the configuration, expand the config in `init.lua` or set this `$HOME/.config/nvim/after/plugin/venkat.lua` :
 
 ```lua
-require('venkat').config.languages = {
-    go = { cmdline = "go run %s", pattern = "main.go" },
-    java = { cmdline = "java %s", pattern = "main.java" },
-    python = { cmdline = "python %s", pattern = "main.py" },
-    rust = { cmdline = "cargo -Zscript %s", pattern = "main.rs" },
-    zig = { cmdline = "zig run %s", pattern = "main.zig" },
-    c = { cmdline = "zig run -lc %s", pattern = "main.c" },
-}
-
+require('venkat').setup({
+    languages = {
+        go = { cmdline = "go run %s", pattern = "demos/*.go,main.go" },
+        java = { cmdline = "java %s", pattern = "demos/*.java,Main.java" },
+        python = { cmdline = "python %s", pattern = "demos/*.py,main.py" },
+        rust = { cmdline = "cargo -Zscript %s", pattern = "main.rs" },
+        zig = { cmdline = "zig run %s", pattern = "main.zig" },
+        c = { cmdline = "zig run -lc %s", pattern = "main.c" },
+}})
 ```
 

--- a/lua/venkat/init.lua
+++ b/lua/venkat/init.lua
@@ -10,6 +10,25 @@ M.config.languages = {
     zig = { cmdline = "zig run %s", pattern = "main.zig" },
 }
 
+function M.setup(opts)
+    opts = opts or {}
+    if opts.default then
+        error "'default' is not a valid value for setyp . See 'defaults'"
+    end
+
+    if opts.languages ~= nil then
+        M.config.languages = opts.languages
+    end
+
+    vim.api.nvim_create_autocmd("BufWritePost", {
+        group = vim.api.nvim_create_augroup("venkatmode", { clear = true }),
+        pattern = require("venkat").config.getPattern(),
+        callback = function()
+            require("venkat").execute()
+        end,
+    })
+end
+
 M.config.getPattern = function()
     local pattern = ""
     for _, value in pairs(M.config.languages) do
@@ -56,14 +75,14 @@ M.execute = function()
     })
 
     local popup = function(bufnum, data)
-            vim.api.nvim_buf_set_keymap(bufnum, 'n', '<Esc>', ':close<CR>', {
-                silent = true,
-                nowait = true,
-                noremap = true
+        vim.api.nvim_buf_set_keymap(bufnum, 'n', '<Esc>', ':close<CR>', {
+            silent = true,
+            nowait = true,
+            noremap = true
 
-            })
-            vim.api.nvim_buf_set_lines(bufnum, -1, -1, false, data)
-            vim.api.nvim_set_current_win(windowId)
+        })
+        vim.api.nvim_buf_set_lines(bufnum, -1, -1, false, data)
+        vim.api.nvim_set_current_win(windowId)
     end
 
 


### PR DESCRIPTION
The plugin now loads with a standard setup function that takes an
optional opts table. The init is just a call to the setup function:
    require("venkat").setup()
or
    require("venkat").setup(opts)

where opts is:
opts = {
    languages = {
        go = { cmdline = "go run %s", pattern = "main.go" },
        java = { cmdline = "java %s", pattern = "Main.java" },
        python = { cmdline = "python %s", pattern = "main.py" },
        rust = { cmdline = "cargo %s", pattern = "main.rs" },
        zig = { cmdline = "zig run %s", pattern = "main.zig" },
    }
}

Signed-off-by: Roy Golan <royg21@gmail.com>
